### PR TITLE
SF/renaming_updateTeam

### DIFF
--- a/app/Actions/Jetstream/UpdateTeam.php
+++ b/app/Actions/Jetstream/UpdateTeam.php
@@ -4,9 +4,9 @@ namespace App\Actions\Jetstream;
 
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
-use Laravel\Jetstream\Contracts\UpdatesTeamNames;
+use App\Interfaces\UpdatesTeam;
 
-class UpdateTeamName implements UpdatesTeamNames
+class UpdateTeam implements UpdatesTeam
 {
     /**
      * Validate and update the given team's details.
@@ -23,7 +23,7 @@ class UpdateTeamName implements UpdatesTeamNames
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'abbreviation' => ['required', 'string', 'max:10'],
-        ])->validateWithBag('updateTeamName');
+        ])->validateWithBag('updateTeam');
 
         $team->forceFill([
             'name' => $input['name'],

--- a/app/Http/Livewire/UpdateTeamForm.php
+++ b/app/Http/Livewire/UpdateTeamForm.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Illuminate\Support\Facades\Auth;
+use App\Interfaces\UpdatesTeam;
+use Livewire\Component;
+
+class UpdateTeamForm extends Component
+{
+    /**
+     * The team instance.
+     *
+     * @var mixed
+     */
+    public $team;
+
+    /**
+     * The component's state.
+     *
+     * @var array
+     */
+    public $state = [];
+
+    /**
+     * Mount the component.
+     *
+     * @param  mixed  $team
+     * @return void
+     */
+    public function mount($team)
+    {
+        $this->team = $team;
+
+        $this->state = $team->withoutRelations()->toArray();
+    }
+
+    /**
+     * Update the team's name.
+     *
+     * @param  App\Interfaces\UpdatesTeam  $updater
+     * @return void
+     */
+    public function updateTeam(UpdatesTeam $updater)
+    {
+        $this->resetErrorBag();
+
+        $updater->update($this->user, $this->team, $this->state);
+
+        $this->emit('saved');
+
+        $this->emit('refresh-navigation-menu');
+    }
+
+    /**
+     * Get the current user of the application.
+     *
+     * @return mixed
+     */
+    public function getUserProperty()
+    {
+        return Auth::user();
+    }
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('teams.update-team-form');
+    }
+}

--- a/app/Interfaces/UpdatesTeam.php
+++ b/app/Interfaces/UpdatesTeam.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Interfaces;
+
+interface UpdatesTeam
+{
+    /**
+     * Validate and update the given team's name.
+     *
+     * @param  mixed  $user
+     * @param  mixed  $team
+     * @param  array  $input
+     * @return void
+     */
+    public function update($user, $team, array $input);
+}

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -8,9 +8,14 @@ use App\Actions\Jetstream\DeleteTeam;
 use App\Actions\Jetstream\DeleteUser;
 use App\Actions\Jetstream\InviteTeamMember;
 use App\Actions\Jetstream\RemoveTeamMember;
-use App\Actions\Jetstream\UpdateTeamName;
+use App\Actions\Jetstream\UpdateTeam;
+use App\Http\Livewire\UpdateTeamForm;
 use Illuminate\Support\ServiceProvider;
-use Laravel\Jetstream\Jetstream;
+use Illuminate\View\Compilers\BladeCompiler;
+use Laravel\Jetstream\Features;
+use Livewire\Livewire;
+use App\Providers\src\Jetstream;
+
 
 class JetstreamServiceProvider extends ServiceProvider
 {
@@ -21,7 +26,19 @@ class JetstreamServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->bind(\Laravel\Jetstream\Jetstream::class, function(){
+            return new \App\Jetstream;
+        });
+
+        $this->app->afterResolving(BladeCompiler::class, function () {
+            if (config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
+
+                if (Features::hasTeamFeatures()) {
+                    Livewire::component('teams.update-team-form', UpdateTeamForm::class);
+
+                }
+            }
+        });
     }
 
     /**
@@ -34,7 +51,7 @@ class JetstreamServiceProvider extends ServiceProvider
         $this->configurePermissions();
 
         Jetstream::createTeamsUsing(CreateTeam::class);
-        Jetstream::updateTeamNamesUsing(UpdateTeamName::class);
+        Jetstream::updateTeamUsing(UpdateTeam::class);
         Jetstream::addTeamMembersUsing(AddTeamMember::class);
         Jetstream::inviteTeamMembersUsing(InviteTeamMember::class);
         Jetstream::removeTeamMembersUsing(RemoveTeamMember::class);

--- a/app/Providers/src/Jetstream.php
+++ b/app/Providers/src/Jetstream.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Providers\src;
+
+use App\Interfaces\UpdatesTeam;
+
+class Jetstream extends \Laravel\Jetstream\Jetstream
+{
+
+    /**
+     * Register a class / callback that should be used to update team names.
+     *
+     * @param  string  $class
+     * @return void
+     */
+    public static function updateTeamUsing(string $class)
+    {
+        return app()->singleton(UpdatesTeam::class, $class);
+    }
+
+    /**
+     * Register a class / callback that should be used to add team members.
+     *
+     * @param  string  $class
+     * @return void
+     */
+
+}

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -7,7 +7,7 @@
 
     <div>
         <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
-            @livewire('teams.update-team-name-form', ['team' => $team])
+            @livewire('teams.update-team-form', ['team' => $team])
 
             @livewire('teams.team-member-manager', ['team' => $team])
 

--- a/resources/views/teams/update-team-form.blade.php
+++ b/resources/views/teams/update-team-form.blade.php
@@ -1,4 +1,4 @@
-<x-jet-form-section submit="updateTeamName">
+<x-jet-form-section submit="updateTeam">
     <x-slot name="title">
         {{ __('Team Details') }}
     </x-slot>


### PR DESCRIPTION
'UpdateTeamName' Klassen und dazugehörigen Templates wurden angelegt und in der App neu erstellt, falls noch nicht vorhanden, und eine Namensänderung im Dateinamen erforderten.
Der Rest wurde in 'JetstreamServiceProvider.php' überschrieben. (Template-alias, Erweiterung der Klasse Jetstream mit der umbenannten Methode)
